### PR TITLE
Default progress timeout

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -2132,5 +2132,8 @@
         return m.module(document.getElementById(finalOptions.divID), tb );
     };
 
+    // Expose some internal classes to the public
+    runTB.Notify = Notify;
+
     return runTB;
 }));

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -138,7 +138,7 @@
     /**
      * Implementation of a notification system, added to each row
      * @param {String} [message] Notification message
-     * @param {String} [tpe] One of the bootstrap alert types (info, danger, warning, success, primary, default)
+     * @param {String} [type] One of the bootstrap alert types (info, danger, warning, success, primary, default)
      * @param {Number} [column] Which column the message should replace, if empty the entire row will be used
      * @param {Number} [timeout] Milliseconds that takes for message to be removed.
      * @constructor
@@ -148,7 +148,7 @@
         this.type = type || "info";
         this.message =  message || 'Hello';
         this.on = false;
-        this.timeout = timeout || 3000;
+        this.timeout = timeout === undefined ? 3000 : timeout;
         this.css = '';
         this.toggle = function () {
             this.on = !this.on;

--- a/tests/qunit/tests.js
+++ b/tests/qunit/tests.js
@@ -946,3 +946,13 @@ test('Dropzone accept, and related event hooks', function (assert) {
 
     tb.destroy();
 });
+
+QUnit.module("Notify tests", {});
+
+test('Notify timeout', function(assert) {
+    var notify = new Treebeard.Notify();
+    assert.equal(notify.timeout, 3000, 'defaults to 3000');
+
+    var notify2 = new Treebeard.Notify('foo', 'info', 42, 0);
+    assert.equal(notify2.timeout, 0, 'can be set to 0');
+});


### PR DESCRIPTION
Fixes a bug in setting a `Notify`'s timeout to `0`.

See https://github.com/CenterForOpenScience/osf.io/pull/1547