### PR TITLE
Add cache busting for mithril to fix IE bugs

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -24,6 +24,22 @@
 }(this, function (jQuery, m) {
     "use strict";
 
+    //Force cache busting in IE
+    var oldmrequest = m.request;
+    m.request = function() {
+        var buster;
+        var requestArgs = arguments[0];
+
+        if (requestArgs.url.indexOf('?') !== -1) {
+            buster = '&_=';
+        } else {
+            buster = '?_=';
+        }
+
+        requestArgs.url += (buster + (new Date().getTime()));
+        return oldmrequest.apply(this, arguments);
+    };
+
     // Indexes by id, shortcuts to the tree objects. Use example: var item = Indexes[23];
     var Indexes = {},
     // Item constructor


### PR DESCRIPTION
Add a `_=[current epoch time]` to the end of urls.