### PR TITLE
Only distribute the dist/ directory and don't pin to jQuery 1.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,16 +18,16 @@
   "license": "Apache 2",
   "private": false,
   "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
+    "*",
+    "!dist",
+    "!dist/**/*",
+    "!README.md",
+    "!package.json"
   ],
   "dependencies": {
     "jquery-ui": ">=1.10.4",
     "mithril": ">=0.1.22",
-    "jquery": "~1.11.0",
+    "jquery": ">=1.11.0",
     "bootstrap": "~3.3.2"
   }
 }


### PR DESCRIPTION
When installing with bower, only the `dist/` directory, `package.json`, and `README.md` will be included. Also, allow jQuery >=1.11 to avoid dependency conflicts.