### PR TITLE
Allow later versions of mithril and organize dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.8",
-    "through2": "^0.5.1"
+    "through2": "^0.5.1",
     "gulp": "^3.8.6",
     "gulp-concat": "^2.3.3",
     "gulp-less": "^1.3.6",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Implementation of grid data display through Mithril",
   "main": "gulpfile.js",
   "dependencies": {
+    "mithril": ">=0.1.22"
+  },
+  "devDependencies": {
     "bower": "^1.3.8",
+    "through2": "^0.5.1"
     "gulp": "^3.8.6",
     "gulp-concat": "^2.3.3",
     "gulp-less": "^1.3.6",
@@ -13,10 +17,6 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^2.2.20",
     "less": "^1.7.3",
-    "mithril": "^0.1.22",
-    "through2": "^0.5.1"
-  },
-  "devDependencies": {
     "node-qunit-phantomjs": "^1.2.0",
     "qunitjs": "^1.15.0"
   },


### PR DESCRIPTION
 `package.json` was inconsistent with `bower.json` w/r/t pinning mithril. This allows mithril>=0.1.22. Also it moved build tools to `devDependencies` rather than `dependencies`.