### PR TITLE
Switch order of lazyLoadOnLoad and ontogglefolder in tb.toggleFolder

### DIFF
--- a/dist/treebeard.js
+++ b/dist/treebeard.js
@@ -979,11 +979,11 @@
                         })
                         .then(function _getUrlFlatten() {
                             self.flatten(self.treeData.children, self.visibleTop);
-                            if (self.options.lazyLoadOnLoad) {
-                                self.options.lazyLoadOnLoad.call(self, tree);
-                            }
                             if (self.options.ontogglefolder) {
                                 self.options.ontogglefolder.call(self, tree, event);
+                            }
+                            if (self.options.lazyLoadOnLoad) {
+                                self.options.lazyLoadOnLoad.call(self, tree);
                             }
                         });
 


### PR DESCRIPTION
In tb.toggleFolder, call ontogglefolder before lazyLoadOnLoad. Allows functions within lazyLoadOnLoad (or anything else that executes after ontogglefolder) to execute based on the ontogglefolder event.