### PR TITLE
Update #destroy to clone, remove, and re-add node

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1904,7 +1904,14 @@
              * Because DOM objects are removed their events are going to be cleaned up.
              */
         this.destroy = function _destroy() {
-            $('#' + self.options.divID).html(''); // Empty HTML
+            var el = document.getElementById(self.options.divID);
+            var parent = el.parentNode;
+            var clone = el.cloneNode(true);
+            while (clone.firstChild) {
+                clone.removeChild(clone.firstChild);
+            }
+            parent.removeChild(el);
+            parent.appendChild(clone);
             if (self.dropzone) {
                 _destroyDropzone();
             } // Destroy existing dropzone setup


### PR DESCRIPTION
# Purpose

Treebeard's #destroy method was behaving unexpectedly, sometimes causing errors in removing and rebinding the grid.

# Changes

Actually remove the bound DOM node. First clone it, clear it's contents, then reappend it. 

# Side Effects

None