### PR TITLE
Minor optimizations to onScroll handler

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -43,6 +43,48 @@
         return oldmrequest.apply(this, arguments);
     };
 
+    // From Underscore.js, MIT License
+    //
+    // Returns a function, that, as long as it continues to be invoked, will not
+    // be triggered. The function will be called after it stops being called for
+    // N milliseconds. If `immediate` is passed, trigger the function on the
+    // leading edge, instead of the trailing.
+    var debounce = function(func, wait, immediate) {
+        var timeout, args, context, timestamp, result;
+
+        var later = function() {
+            var last = new Date().getTime() - timestamp;
+
+            if (last < wait && last >= 0) {
+                timeout = setTimeout(later, wait - last);
+            } else {
+                timeout = null;
+                if (!immediate) {
+                    result = func.apply(context, args);
+                    if (!timeout) {
+                        context = args = null;
+                    }
+                }
+            }
+        };
+
+        return function() {
+            context = this;
+            args = arguments;
+            timestamp = new Date().getTime();
+            var callNow = immediate && !timeout;
+            if (!timeout) {
+                timeout = setTimeout(later, wait);
+            }
+            if (callNow) {
+                result = func.apply(context, args);
+                context = args = null;
+            }
+
+            return result;
+        };
+    };
+
     // Indexes by id, shortcuts to the tree objects. Use example: var item = Indexes[23];
     var Indexes = {},
         // Item constructor
@@ -1135,7 +1177,8 @@
          * Refreshes the view to start the the location where begin is the starting index
          * @param {Number} begin The index location of visible indexes to start at.
          */
-        this.refreshRange = function _refreshRange(begin) {
+        this.refreshRange = function _refreshRange(begin, redraw) {
+            redraw = redraw !== undefined ? redraw : true; // redraw by default
             var len = self.visibleIndexes.length,
                 range = [],
                 counter = 0,
@@ -1154,7 +1197,11 @@
                 counter = counter + 1;
             }
             self.showRange = range;
-            m.redraw(true);
+            // TODO: Not sure if the redraw param is necessary. We can probably
+            // Use m.start/endComputtion to avoid successive redraws
+            if (redraw) {
+                m.redraw(true);
+            }
         };
 
         /**
@@ -1665,24 +1712,26 @@
         /**
          * Update view on scrolling the table
          */
-        this.onScroll = function _scrollHook() {
+        this.onScroll = debounce(function _scrollHook() {
             if (!self.options.paginate) {
+                m.startComputation();
+                var $this = $(this);
                 var scrollTop, itemsHeight, innerHeight, location, index;
                 itemsHeight = self.calculateHeight();
-                innerHeight = $(this).children('.tb-tbody-inner').outerHeight();
-                scrollTop = $(this).scrollTop();
+                innerHeight = $this.children('.tb-tbody-inner').outerHeight();
+                scrollTop = $this.scrollTop();
                 location = scrollTop / innerHeight * 100;
                 index = Math.floor(location / 100 * self.visibleIndexes.length);
                 self.rangeMargin = scrollTop;
-                self.refreshRange(index);
-                m.redraw(true);
+                self.refreshRange(index, false);
                 self.lastLocation = scrollTop;
                 self.highlightMultiselect();
                 if (self.options.onscrollcomplete) {
                     self.options.onscrollcomplete.call(self);
                 }
+                m.endComputation();
             }
-        };
+        }, this.options.scrollDebounce);
 
         /**
          * Initialization functions after the main body of the table is loaded
@@ -2508,6 +2557,7 @@
             // Item = item where selection is coming from
             // direction = the directino of the arrow key
         };
+        this.scrollDebounce = 15; // milliseconds
     };
 
     /**


### PR DESCRIPTION
Adds a number of optimizations to the onScroll handler.

- debounce calls to onScroll
- Remove unnecessary redraw
- Cache $(this) selector