### PR TITLE
ensures titles are component names when filtering search results

### DIFF
--- a/dist/treebeard.js
+++ b/dist/treebeard.js
@@ -901,7 +901,7 @@
                 o;
             for (i = 0; i < cols.length; i++) {
                 o = cols[i];
-                if (o.filter && item.data[o.data].toString().toLowerCase().indexOf(filter) !== -1) {
+                if (o.filter && o.data === 'name' && item.data[o.data].toString().toLowerCase().indexOf(filter) !== -1) {
                     titleResult = true;
                 }
             }


### PR DESCRIPTION
**Purpose**
fix error where when filtering search results with nested components. closes [OSF Issue 3013](https://github.com/CenterForOpenScience/osf.io/issues/3013)

**Changes**
Adds condition to ensure titles are component names.

**Side Effects**
None that I know of.