### PR TITLE
fix: declare event var when dismissing modal

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -2143,7 +2143,7 @@
                                 }, [
                                     m('.modal-content', {
                                         'class': ctrl.modal.css,
-                                        onclick : function() {
+                                        onclick : function(event) {
                                             event.stopPropagation();
                                             return true;
                                         }


### PR DESCRIPTION
Hey @caneruguz,

When testing Henrique's manyfile upload manager, I kept getting an error when dismissing the modal, that was caused by `event` not begin declared in the dismiss function.  It didn't seem to mess anything else up, perhaps because the modal was being destroyed? Not sure.

Cheers,
Fitz