### PR TITLE
[RFR][Feature]OSF-5847 add check for dataLocation option during LazyLoad

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1062,14 +1062,23 @@
                                     value = self.options.lazyLoadPreprocess.call(self, value);
                                 }
                                 if (!$.isArray(value)) {
-                                    value = value.data;
+                                    if (self.options.dataLocation && self.options.dataLocation in value.data){
+                                        value = value.data[self.options.dataLocation];
+                                    } else {
+                                        value = value.data;
+                                    }
                                 }
                                 var isUploadItem = function(element) {
                                     return element.data.tmpID;
                                 };
                                 tree.children = tree.children.filter(isUploadItem);
                                 for (i = 0; i < value.length; i++) {
-                                    child = self.buildTree(value[i], tree);
+                                    if (self.options.dataLocation && self.options.dataLocation in value[i]){
+                                        var data = value[i][self.options.dataLocation];
+                                    } else {
+                                        var data = value[i];
+                                    }
+                                    child = self.buildTree(data, tree);
                                     tree.add(child);
                                 }
                                 tree.open = true;


### PR DESCRIPTION
## Purpose
[OSF-5847](https://openscience.atlassian.net/browse/OSF-5847)
Allow for handling LazyLoads against API where treebeard data will not be found at the root level of the data returned from the API.

## Changes
update scripts/grid.js to check for and use self.options.dataLocation when dealing with data retrieved from LazyLoad

## Side effects
An erroneous self.options.dataLocation value will break treebeard LazyLoad API handling

#OSF-5847