### PR TITLE
[WIP][Feature]OSF-5847 add check for dataLocation option during LazyLoad

### DIFF
--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1029,6 +1029,7 @@
             var len = self.flatData.length,
                 tree = Indexes[self.flatData[index].id],
                 item = self.flatData[index],
+                data,
                 child,
                 skip = false,
                 skipLevel = item.depth,
@@ -1064,14 +1065,15 @@
                                     value = self.options.lazyLoadPreprocess.call(self, value);
                                 }
                                 if (!$.isArray(value)) {
-                                    value = value.data;
+                                    value = self.options.dataLocation ? self.options.dataLocation(value.data) : value.data;
                                 }
                                 var isUploadItem = function(element) {
                                     return element.data.tmpID;
                                 };
                                 tree.children = tree.children.filter(isUploadItem);
                                 for (i = 0; i < value.length; i++) {
-                                    child = self.buildTree(value[i], tree);
+                                    data = self.options.dataLocation ? self.options.dataLocation(value[i]) : value[i];
+                                    child = self.buildTree(data, tree);
                                     tree.add(child);
                                 }
                                 tree.open = true;


### PR DESCRIPTION
## Purpose
[OSF-5847](https://openscience.atlassian.net/browse/OSF-5847)
Allow for handling LazyLoads against API where treebeard data will not be found at the root level of the data returned from the API.
  This PR is a requirement of [OSF PR 5240](https://github.com/CenterForOpenScience/osf.io/pull/5240)

## Changes
update scripts/grid.js to check for and use self.options.dataLocation when dealing with data retrieved from LazyLoad

## Side effects
An erroneous self.options.dataLocation value will break treebeard LazyLoad API handling

#OSF-5847