### PR TITLE
OSF-4442 Fix treebeard multiselect when scrolling.

### DIFF
--- a/dist/treebeard.js
+++ b/dist/treebeard.js
@@ -1388,8 +1388,8 @@
                 if (self.multiselected().length === 0) {
                     self.multiselected().push(tree);
                 } else {
-                    begin = self.returnRangeIndex(self.multiselected()[0].id);
-                    end = self.returnRangeIndex(id);
+                    begin = self.returnIndex(self.multiselected()[0].id);
+                    end = self.returnIndex(id);
                     if (begin > end) {
                         direction = 'up';
                     } else {
@@ -1398,13 +1398,13 @@
                     if (begin !== end) {
                         self.multiselected([]);
                         if (direction === 'down') {
-                            for (i = begin; i < end + 1; i++) {
-                                self.multiselected().push(Indexes[self.flatData[self.showRange[i]].id]);
+                            for (i = begin; i <= end; i++) {
+                                self.multiselected().push(Indexes[self.flatData[i].id]);
                             }
                         }
                         if (direction === 'up') {
-                            for (i = begin; i > end - 1; i--) {
-                                self.multiselected().push(Indexes[self.flatData[self.showRange[i]].id]);
+                            for (i = begin; i >= end; i--) {
+                                self.multiselected().push(Indexes[self.flatData[i].id]);
                             }
                         }
                     }


### PR DESCRIPTION
<h3>
Purpose
</h3>
Treebeard doesn't behave when pressing shift and multiselect starting from an element scrolled out of range.

<h3>
Changes
</h3>
I believe the original version was developed based on the assumption that users only multi-select elements that lies within visible range. Thus, when the start element is scrolled out of range, "returnRangeIndex()" returns "undefined" since it only search within the the list of elements in visible range (self.showRange).
Thus, changes are made to treebeard.js to make use of "returnIndex()" instead of "returnRangeIndex()". Conditions for two for-loops are changed to add items to the "multiselected" array.
See JIRA ticket (https://openscience.atlassian.net/browse/OSF-4442) for gif animation showing the effect of the change.